### PR TITLE
fix: locating i18n files error

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -20,6 +20,9 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    backend: {
+      loadPath: 'locales/{{lng}}/{{ns}}.json',
+    },
     fallbackLng: {
       default: ['en'],
     },


### PR DESCRIPTION
Thank you for this project, it has solved the frustration of frequently losing connection when using the official https://chat.openai.com.

When I forked and deployed this project in GitHub Page myself, I found that **it loaded the i18n files from the root path**, e.g., `https://username.github.io/locales/zh-CN/main.json`. However, my GitHub Page URL is `https://username.github.io/FreeChatGPT`.

### Expected Behavior

It loads i18n files starting from the base url, e.g., `https://username.github.io/FreeChatGPT/locales/zh-CN/main.json`.

### Current Behavior

It loads i18n files starting from the root path, e.g., `https://username.github.io/locales/zh-CN/main.json`.

### Steps to Reproduce 

1. Opens `F12 Developer Tools`.
2. Enters the website https://lujunbofan2019.github.io/FreeChatGPT/
3. Watchs the requests in `Developer Tools`.

<img src="https://user-images.githubusercontent.com/35210901/227207572-26459a72-b367-4b9b-b0ce-3b54428bab1e.png" width="500" >

### After the fix

1. Opens `F12 Developer Tools`.
2. Enters the website https://zhangt2333.github.io/FreeChatGPT/
3. Watchs the requests in `Developer Tools`.

<img src="https://user-images.githubusercontent.com/35210901/227209134-742ad03a-af18-4df9-91ed-0edc932cb21b.png" width="500" >