### PR TITLE
ci: enable write permission in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
 
@@ -29,4 +31,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           user_name: 'github-actions[bot]'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -117,7 +117,6 @@ Free ChatGPT 已经包含了大量的功能。您可以使用以下功能：
 1. 创建一个 GitHub 账户（如果您还没有账户）。
 1. 给此[存储库](https://github.com/ztjhz/FreeChatGPT) 一个星星 ⭐️
 1. Fork 此[存储库](https://github.com/ztjhz/FreeChatGPT)
-1. Repository settings > Secrets > Actions > General > 勾选 "Read and write permissions"
 1. 在 fork 之后的存储库中点击 `Actions`
    ![image](https://user-images.githubusercontent.com/59118459/223751928-cf2b91b9-4663-4a36-97de-5eb751b32c7e.png)
 1. 在左侧边栏中，点击 `Deploy to GitHub Pages`

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ If you'd like to run your own instance of Free ChatGPT, you can easily do so by 
 1. Create a GitHub account (if you don't have one already)
 1. Star this [repository](https://github.com/ztjhz/FreeChatGPT) ⭐️
 1. Fork this [repository](https://github.com/ztjhz/FreeChatGPT)
-1. Repository settings > Secrets > Actions > General > Tick "Read and write permissions"
 1. In your forked repository, click on `Actions`
    ![image](https://user-images.githubusercontent.com/59118459/223751928-cf2b91b9-4663-4a36-97de-5eb751b32c7e.png)
 1. In the left sidebar, click on `Deploy to GitHub Pages`


### PR DESCRIPTION
Pros:
* It saves a step for users who want to deploy their own [FreeChatGPT](https://github.com/ztjhz/FreeChatGPT).
* It provides additional security for the repository since the GitHub Page workflow requires write access, but not all workflows do.