### PR TITLE
feat: add shortcut for "save and submit" when editing message

### DIFF
--- a/src/components/Chat/ChatContent/Message/MessageContent.tsx
+++ b/src/components/Chat/ChatContent/Message/MessageContent.tsx
@@ -312,7 +312,7 @@ const EditView = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.ctrlKey || e.shiftKey) && e.key === 'Enter') {
       e.preventDefault();
-      if (sticky) {
+      if (sticky || e.ctrlKey && e.shiftKey) {
         handleSaveAndSubmit();
         resetTextAreaHeight();
       } else handleSave();


### PR DESCRIPTION
Save and submit the edited message when ctrl and shift key been pressed simultaneously.
We should consider adding tooltips or help text for frequently used shortcuts.